### PR TITLE
Don't save profiles on exit

### DIFF
--- a/.github/workflows/checkTranslatorsComments.yml
+++ b/.github/workflows/checkTranslatorsComments.yml
@@ -32,7 +32,7 @@ jobs:
         pip install scons markdown
         sudo apt update
         sudo apt install gettext
-    
+
     - name: Generate the .pot file
       run: scons pot
 
@@ -46,7 +46,7 @@ jobs:
       #  checkPot.EXPECTED_MESSAGES_WITHOUT_COMMENTS = set()
       #  res = checkPot.checkPot('$(ls *.pot)')
       #  exit(res)
-      #shell: python 
+      #shell: python
       run: |
         python -c "import checkPot;checkPot.EXPECTED_MESSAGES_WITHOUT_COMMENTS = set();exit(checkPot.checkPot('$(ls *.pot)'))"
         echo "nb_errors=$?" >> "$GITHUB_OUTPUT"
@@ -61,4 +61,3 @@ jobs:
         echo "Translators comments: FAIL"
         exit 1;
         fi
-      

--- a/addon/globalPlugins/readonlyProfiles.py
+++ b/addon/globalPlugins/readonlyProfiles.py
@@ -25,6 +25,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		pre_configSave.register(preConfigSaveHandler)
 
 	def terminate(self):
+		if config.conf["general"]["saveConfigurationOnExit"]:
+			# Don't unregister the handler, so that configuration can be saved on exit.
+			return
 		pre_configSave.unregister(preConfigSaveHandler)
 
 	@script(

--- a/buildVars.py
+++ b/buildVars.py
@@ -37,7 +37,7 @@ addon_info = {
     # Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
     "addon_minimumNVDAVersion": "2025.1",
     # Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-    "addon_lastTestedNVDAVersion": "2025.1.2",
+    "addon_lastTestedNVDAVersion": "2025.2",
     # Add-on update channel (default is None, denoting stable releases,
     # and for development releases, use "dev".)
     # Do not change unless you know what you are doing!


### PR DESCRIPTION
- **Don't unregister handler on terminate if configuration should be saved on exit**
- **Update buildVars**

<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None.
Reported on this [thread of the add-ons mailing list](https://nvda-addons.groups.io/g/nvda-addons/topic/113830942).
### Summary of the issue:
Though NVDA is configured to sabe configuration on exit, profiles shouldn't be saved with this add-on.
### Description of how this pull request fixes the issue:
In the terminate method of the plugin, if configuration should be saved, return so the handler to clear dirty profiles before sabe configuration is not unregistered.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
None.